### PR TITLE
Shell for pwd in build for WinPS

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -94,7 +94,6 @@ jobs:
         run: |
           $tag = "${{github.ref}}".Split("/")["${{github.ref}}".Split("/").Length -1]
           echo "::set-env name=GITHUB_TAG::$(echo $tag)"
-          echo "::set-env name=CARAMELC_STDLIB_PATH::${{ matrix.stdlib_path }}"
 
       - name: Update Opam
         run: opam update --yes

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export
 
-CARAMELC = $(PWD)/caramelc.exe
-CARAMELC_STDLIB_PATH ?= $(PWD)/_build/default/src/stdlib
+CARAMELC = $(shell pwd)/caramelc.exe
+CARAMELC_STDLIB_PATH ?= $(shell pwd)/_build/default/src/stdlib
 
 .PHONY: build
 build:


### PR DESCRIPTION
connects #29

I think this will simplifiy the build such that we won't need the CARAMEL_STDLIB_PATH in the workflow file, for the windows build.
