### PR TITLE
Add docs Github Actions workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+
+    env:
+      MDBOOK_VERSION: 0.4.6
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install mdbook
+      run: |
+        sudo apt install curl tar
+        mkdir bin
+        eval 'curl -Lo bin/mdbook.tar.gz "https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz"'
+        tar -xf bin/mdbook.tar.gz -C bin
+        rm bin/mdbook.tar.gz
+        echo "`pwd`/bin" >> $GITHUB_PATH
+
+    - name: Generate docs
+      run: |
+        make manual
+
+    - name: Init new repo in docs folder, commit and force push generated files
+      run: |
+        cd docs
+        git init
+        git add -A
+        git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        git config --local user.name "$GITHUB_ACTOR"
+        git commit -m 'deploy'
+        git push "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY" HEAD:gh-pages --force


### PR DESCRIPTION
This new `docs` workflow automates the process of regenerating the `manual/src` files into the `docs/manual` output, and pushes the whole `docs` directory to a separate `gh-pages` branch.

You can see the workflow run at https://github.com/michallepicki/caramel-mdbook-automated/runs/1764689663 and preview the deployed result at https://michallepicki.github.io/caramel-mdbook-automated/manual/ (it's possible that some links are broken because in my fork the manual is deployed to a doubly nested directory, so if some are then I wouldn't worry about that. I see that the website [index page](https://michallepicki.github.io/caramel-mdbook-automated/) renders without styles / broken because of that.).

After this gets deployed, and Github Pages source is reconfigured, it's possible that a workflow re-run (or new push to `main`) will be needed to get the website deployed from the new source.

Closes #47 