### PR TITLE
added parser entry point for terms

### DIFF
--- a/erlang/src/erl_parse.ml
+++ b/erlang/src/erl_parse.ml
@@ -1,7 +1,8 @@
-let from_file source_file =
+let from_file parse source_file =
   let ic = open_in_bin source_file in
   let lexbuf = Lexing.from_channel ic in
-  match Erl_parser.module_file Erl_lexer.token lexbuf with
+  (* match Erl_parser.module_file Erl_lexer.token lexbuf with *)
+  match parse Erl_lexer.token lexbuf with
   | exception exc ->
       let msg =
         Printf.sprintf "In %s, at offset %d: syntax error.\n  %s%!" source_file
@@ -10,3 +11,11 @@ let from_file source_file =
       in
       Error (`Parser_error msg)
   | x -> Ok x
+
+let exprs_from_file source_file = 
+  let parse = Erl_parser.exprs_file in
+  from_file parse source_file
+
+let from_file source_file = 
+  let parse = Erl_parser.module_file in
+  from_file parse source_file

--- a/erlang/src/erl_parse.ml
+++ b/erlang/src/erl_parse.ml
@@ -1,7 +1,6 @@
 let from_file parse source_file =
   let ic = open_in_bin source_file in
   let lexbuf = Lexing.from_channel ic in
-  (* match Erl_parser.module_file Erl_lexer.token lexbuf with *)
   match parse Erl_lexer.token lexbuf with
   | exception exc ->
       let msg =
@@ -12,10 +11,10 @@ let from_file parse source_file =
       Error (`Parser_error msg)
   | x -> Ok x
 
-let exprs_from_file source_file = 
-  let parse = Erl_parser.exprs_file in
+let terms_from_file source_file = 
+  let parse = Erl_parser.terms_from_file in
   from_file parse source_file
 
-let from_file source_file = 
-  let parse = Erl_parser.module_file in
+let module_from_file source_file = 
+  let parse = Erl_parser.module_from_file in
   from_file parse source_file

--- a/erlang/src/erl_parse.mli
+++ b/erlang/src/erl_parse.mli
@@ -1,4 +1,4 @@
-val from_file :
+val module_from_file :
   string -> (Erl_ast.structure, [> `Parser_error of string ]) result
-val exprs_from_file :
+val terms_from_file :
   string -> (Erl_ast.expr list, [> `Parser_error of string ]) result

--- a/erlang/src/erl_parse.mli
+++ b/erlang/src/erl_parse.mli
@@ -1,2 +1,4 @@
 val from_file :
   string -> (Erl_ast.structure, [> `Parser_error of string ]) result
+val exprs_from_file :
+  string -> (Erl_ast.expr list, [> `Parser_error of string ]) result

--- a/erlang/src/erl_parser.messages
+++ b/erlang/src/erl_parser.messages
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
 
-module_file: EOF
+module_from_file: EOF
 
 You're trying to read an empty .erl file.
 The smallest valid Erlang module will still include a

--- a/erlang/src/erl_parser.mly
+++ b/erlang/src/erl_parser.mly
@@ -117,7 +117,8 @@ HASH
 let module_file := is = module_item+; EOF; { is }
 
 let terminated_exprs :=
-  | e=expr; DOT; {[e]}
+  | {[]}
+  | comment; es=terminated_exprs; { es }
   | e=expr; DOT; es=terminated_exprs; { e::es }
 
 let exprs_file := is = terminated_exprs; EOF; { is }

--- a/erlang/src/erl_parser.mly
+++ b/erlang/src/erl_parser.mly
@@ -315,7 +315,7 @@ let expr_fun_ref :=
 
 let expr_list := l = expr_list_dangling; { l }
 
-let expr_tuple := t = tuple(expr); { Expr.tuple t }
+let expr_tuple := t = tuple_for_expr; { Expr.tuple t }
 
 let expr_map :=
   | HASH; LEFT_BRACE; fields = separated_list(COMMA, map_field); RIGHT_BRACE;
@@ -409,6 +409,25 @@ let list1_sep_dangling(separator,X):=
   { [x] }
 
 // this version keeps comments but in doing so must specialise to expr
+let tuple_sep_dangling:=
+| x = expr;
+    { [x] }
+| x = expr; COMMA; xs = expr_list_sep_dangling;
+    { x :: xs }
+| x = expr; COMMA;
+    { [x] }
+| x = expr; c=comment ; xs = expr_list_sep_dangling;
+    { Expr.comment c x :: xs }
+| x = expr; COMMA; c=comment;
+    { [Expr.comment c x] }
+| x = expr; c = comment;
+    { [Expr.comment c x] }
+
+
+let tuple(a) := els = delimited(LEFT_BRACE, list1_sep_dangling(COMMA,a), RIGHT_BRACE); { els }
+let tuple_for_expr 
+   := els = delimited(LEFT_BRACE, tuple_sep_dangling, RIGHT_BRACE); { els }
+
 let expr_list_sep_dangling:=
 | //empty
     { [] }
@@ -420,8 +439,6 @@ let expr_list_sep_dangling:=
     { Expr.comment c x :: xs }
 | x = expr; COMMA; c=comment;
     { [Expr.comment c x] }
-
-let tuple(a) := els = delimited(LEFT_BRACE, list1_sep_dangling(COMMA,a), RIGHT_BRACE); { els }
 
 let expr_list_dangling :=
   (* NOTE: matches [1,2,3] *)

--- a/erlang/src/erl_parser.mly
+++ b/erlang/src/erl_parser.mly
@@ -104,8 +104,8 @@ HASH
 (* EOF *)
 %token <Parse_info.t> EOF
 
-%start <Erl_ast.structure> module_file
-%start <Erl_ast.expr list> exprs_file
+%start <Erl_ast.structure> module_from_file
+%start <Erl_ast.expr list> terms_from_file
 %%
 
 (******************************************************************************
@@ -114,14 +114,14 @@ HASH
  *
  ******************************************************************************)
 
-let module_file := is = module_item+; EOF; { is }
+let module_from_file := is = module_item+; EOF; { is }
 
 let terminated_exprs :=
   | {[]}
   | comment; es=terminated_exprs; { es }
   | e=expr; DOT; es=terminated_exprs; { e::es }
 
-let exprs_file := is = terminated_exprs; EOF; { is }
+let terms_from_file := is = terminated_exprs; EOF; { is }
 
 let module_item :=
   | ~ = comment; { Module_comment comment }
@@ -314,7 +314,6 @@ let expr_fun_ref :=
     { Expr.fun_ref (Name.atom name) ~arity:(int_of_string arity) }
 
 let expr_list := l = expr_list_dangling; { l }
-//let expr_list := l = list_dangling_sep(expr); { l }
 
 let expr_tuple := t = tuple(expr); { Expr.tuple t }
 
@@ -389,25 +388,22 @@ let comment :=
 (**
  * Constructors
  *)
-let list(a) :=
+let unused_list(a) :=
   (* NOTE: matches [1,2,3] *)
   | LEFT_BRACKET; els = separated_list(COMMA, a); RIGHT_BRACKET;
     { Expr.list els }
-
-    (* NOTE: matches [1,2 | Rest] *)
+  (* NOTE: matches [1,2 | Rest] *)
   | LEFT_BRACKET; el1 = separated_list(COMMA, a); PIPE; el2 = a; RIGHT_BRACKET;
     { Expr.cons el1 el2 }
 
-let list0_sep_dangling(separator,X):=
-| //empty
-    { [] }
+let list1_sep_dangling(separator,X):=
 | x = X;
     { [ x ] }
-| x = X; separator; xs = list0_sep_dangling(separator,X);
+| x = X; separator; xs = list1_sep_dangling(separator,X);
     { x :: xs }
-//| x = X; separator;
-//    { [ x ] }
-| x = X; COMMENT ; xs = list0_sep_dangling(separator,X);
+| x = X; separator;
+    { [ x ] }
+| x = X; COMMENT ; xs = list1_sep_dangling(separator,X);
     { x :: xs }
 | x = X; separator; COMMENT;
   { [x] }
@@ -420,24 +416,12 @@ let expr_list_sep_dangling:=
     { [x] }
 | x = expr; COMMA; xs = expr_list_sep_dangling;
     { x :: xs }
-//| x = expr; COMMA;
-//    { [x] }
 | x = expr; c=comment ; xs = expr_list_sep_dangling;
     { Expr.comment c x :: xs }
 | x = expr; COMMA; c=comment;
     { [Expr.comment c x] }
 
-(* let tuple(a) := els = delimited(LEFT_BRACE, separated_list(COMMA,a), RIGHT_BRACE); { els } *)
-(* perhaps shouldn't apply to types *)
-let tuple(a) := els = delimited(LEFT_BRACE, list0_sep_dangling(COMMA,a), RIGHT_BRACE); { els }
-
-let xexpr_list_dangling(a) :=
-  (* NOTE: matches [1,2,3] *)
-  | LEFT_BRACKET; els = list0_sep_dangling(COMMA, a); RIGHT_BRACKET;
-    { Expr.list els }
-  (* NOTE: matches [1,2 | Rest] *)
-  | LEFT_BRACKET; el1 = separated_list(COMMA, a); PIPE; el2 = a; RIGHT_BRACKET;
-    { Expr.cons el1 el2 }
+let tuple(a) := els = delimited(LEFT_BRACE, list1_sep_dangling(COMMA,a), RIGHT_BRACE); { els }
 
 let expr_list_dangling :=
   (* NOTE: matches [1,2,3] *)

--- a/erlang/src/erl_parser.mly
+++ b/erlang/src/erl_parser.mly
@@ -9,7 +9,9 @@ type parse_error =
   | Unknown_type_visibility of string
 
 exception Parse_error of parse_error
-exception Error
+(* interfered with separate compile of parser - for some reason ok as part of 
+caramel build? *)
+(* exception Error *)
 
 let throw x =
   begin match x with
@@ -103,6 +105,7 @@ HASH
 %token <Parse_info.t> EOF
 
 %start <Erl_ast.structure> module_file
+%start <Erl_ast.expr list> exprs_file
 %%
 
 (******************************************************************************
@@ -112,6 +115,12 @@ HASH
  ******************************************************************************)
 
 let module_file := is = module_item+; EOF; { is }
+
+let terminated_exprs :=
+  | e=expr; DOT; {[e]}
+  | e=expr; DOT; es=terminated_exprs; { e::es }
+
+let exprs_file := is = terminated_exprs; EOF; { is }
 
 let module_item :=
   | ~ = comment; { Module_comment comment }
@@ -303,7 +312,8 @@ let expr_fun_ref :=
   | FUN; name = atom; SLASH; (arity,_) = INTEGER;
     { Expr.fun_ref (Name.atom name) ~arity:(int_of_string arity) }
 
-let expr_list := l = list(expr); { l }
+let expr_list := l = expr_list_dangling; { l }
+//let expr_list := l = list_dangling_sep(expr); { l }
 
 let expr_tuple := t = tuple(expr); { Expr.tuple t }
 
@@ -387,8 +397,55 @@ let list(a) :=
   | LEFT_BRACKET; el1 = separated_list(COMMA, a); PIPE; el2 = a; RIGHT_BRACKET;
     { Expr.cons el1 el2 }
 
+let list0_sep_dangling(separator,X):=
+| //empty
+    { [] }
+| x = X;
+    { [ x ] }
+| x = X; separator; xs = list0_sep_dangling(separator,X);
+    { x :: xs }
+//| x = X; separator;
+//    { [ x ] }
+| x = X; COMMENT ; xs = list0_sep_dangling(separator,X);
+    { x :: xs }
+| x = X; separator; COMMENT;
+  { [x] }
 
-let tuple(a) := els = delimited(LEFT_BRACE, separated_list(COMMA, a), RIGHT_BRACE); { els }
+// this version keeps comments but in doing so must specialise to expr
+let expr_list_sep_dangling:=
+| //empty
+    { [] }
+| x = expr;
+    { [x] }
+| x = expr; COMMA; xs = expr_list_sep_dangling;
+    { x :: xs }
+//| x = expr; COMMA;
+//    { [x] }
+| x = expr; c=comment ; xs = expr_list_sep_dangling;
+    { Expr.comment c x :: xs }
+| x = expr; COMMA; c=comment;
+    { [Expr.comment c x] }
+
+(* let tuple(a) := els = delimited(LEFT_BRACE, separated_list(COMMA,a), RIGHT_BRACE); { els } *)
+(* perhaps shouldn't apply to types *)
+let tuple(a) := els = delimited(LEFT_BRACE, list0_sep_dangling(COMMA,a), RIGHT_BRACE); { els }
+
+let xexpr_list_dangling(a) :=
+  (* NOTE: matches [1,2,3] *)
+  | LEFT_BRACKET; els = list0_sep_dangling(COMMA, a); RIGHT_BRACKET;
+    { Expr.list els }
+  (* NOTE: matches [1,2 | Rest] *)
+  | LEFT_BRACKET; el1 = separated_list(COMMA, a); PIPE; el2 = a; RIGHT_BRACKET;
+    { Expr.cons el1 el2 }
+
+let expr_list_dangling :=
+  (* NOTE: matches [1,2,3] *)
+  (* | LEFT_BRACKET; els = list0_sep_dangling(COMMA, a); RIGHT_BRACKET; *)
+  | LEFT_BRACKET; els = expr_list_sep_dangling; RIGHT_BRACKET;
+    { Expr.list els }
+  (* NOTE: matches [1,2 | Rest] *)
+  | LEFT_BRACKET; el1 = separated_list(COMMA, expr); PIPE; el2 = expr; RIGHT_BRACKET;
+    { Expr.cons el1 el2 }
 
 (**
  * Terminals
@@ -400,7 +457,12 @@ let literal :=
   | (n, _) = INTEGER; { Const.integer n }
   | (n, _) = FLOAT; { Const.float n }
   | (a, _) = ATOM; { Const.atom (Atom.mk a) }
-  | (s, _) = STRING; { Const.string s }
+  (* | (s, _) = STRING; { Const.string s } *)
+  | s = juxtaposed_string; { Const.string s }
+
+let juxtaposed_string :=
+  | (s, _) = STRING; { s }
+  | ms = juxtaposed_string; (s, _) = STRING; { ms^s }
 
 let type_name :=
   | (a, _) = ATOM; { Name.atom (Atom.mk a) }


### PR DESCRIPTION
I  modified the expr_list at the last moment to include comments (attached to expressions!)
instead of dropping them.

I would imagine erlang would actually entertain dangling separators because
it makes commenting out code easy, which the wxapi.conf file alerted me to :)

the tuple rule is shared between expr/type so type is inheriting that dangliness.
is an empty tuple {} valid? if not then list0... needs to become list1...