### PR TITLE
Adjust the GitHub bug template for the project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,11 +11,10 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+Steps to reproduce the behavior, for example:
+1. Create a file containing...
+2. Run command...
+3. See error...
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
@@ -23,16 +22,10 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Environment (please complete the following information):**
+ - OS: [e.g. macOS, Linux, Windows]
+ - Caramel version [e.g. 0.1]
+ - Erlang version (e.g. 23.2.4)
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
The previous bug template was written as if Caramel was a web application