### PR TITLE
fix: Support OCaml style floating point syntax without trailing numbers after dot

### DIFF
--- a/erlang/src/erl_ast_helper.ml
+++ b/erlang/src/erl_ast_helper.ml
@@ -51,7 +51,10 @@ module Const = struct
 
   let string str = Lit_string str
 
-  let float str = Lit_float str
+  let float str =
+    match str.[String.length str - 1] == '.' with
+    | false -> Lit_float str
+    | true -> Lit_float (str ^ "0")
 
   let atom a = Lit_atom a
 end

--- a/tests/compiler/expressions.t/literals.ml
+++ b/tests/compiler/expressions.t/literals.ml
@@ -1,6 +1,7 @@
 let integer () = 1
 
 let float () = 1.0
+let float_without_trailing_zero () = 1.
 
 let character () = 'c'
 

--- a/tests/compiler/expressions.t/run.t
+++ b/tests/compiler/expressions.t/run.t
@@ -269,6 +269,7 @@
   -export([bool_true/0]).
   -export([character/0]).
   -export([float/0]).
+  -export([float_without_trailing_zero/0]).
   -export([integer/0]).
   -export([string/0]).
   
@@ -277,6 +278,9 @@
   
   -spec float() -> float().
   float() -> 1.0.
+  
+  -spec float_without_trailing_zero() -> float().
+  float_without_trailing_zero() -> 1.0.
   
   -spec character() -> char().
   character() -> 'c'.


### PR DESCRIPTION
closes #55

(not sure if changing the `erl_printer` is the correct fix so I'm happy to change if it's not)