### PR TITLE
fix(compiler): do not prioritize using local functions over functions called through module qualifiers

### DIFF
--- a/caramel/compiler/ocaml_to_erlang/fun.ml
+++ b/caramel/compiler/ocaml_to_erlang/fun.ml
@@ -183,22 +183,22 @@ and mk_expression exp ~var_names ~modules ~functions ~module_name =
          2. qualified and external, refering to a module that is not nested
          3. unqualified, and thus refering to a function reference
       *)
-      if name_in_var_names ~var_names var_name then Expr.ident var_name
-      else
-        match name with
-        | Erlang.Ast.Qualified_name
-            { n_mod = Atom_name n_mod; n_name = Atom_name n_name } ->
-            let name =
-              match val_kind with
-              | Val_prim prim -> (
-                  let prim_name = prim.prim_name |> String.trim in
-                  match String.length prim_name > 0 with
-                  | true -> Atom.mk prim_name
-                  | false -> n_name)
-              | _ -> n_name
-            in
-            Expr.ident (namespace_qualified_name n_mod name)
-        | _ ->
+      match name with
+      | Erlang.Ast.Qualified_name
+          { n_mod = Atom_name n_mod; n_name = Atom_name n_name } ->
+          let name =
+            match val_kind with
+            | Val_prim prim -> (
+                let prim_name = prim.prim_name |> String.trim in
+                match String.length prim_name > 0 with
+                | true -> Atom.mk prim_name
+                | false -> n_name)
+            | _ -> n_name
+          in
+          Expr.ident (namespace_qualified_name n_mod name)
+      | _ ->
+          if name_in_var_names ~var_names var_name then Expr.ident var_name
+          else
             let name = Names.atom_of_longident txt in
             let arity =
               match find_function_by_name ~functions name with

--- a/tests/compiler/expressions.t/names.ml
+++ b/tests/compiler/expressions.t/names.ml
@@ -15,8 +15,6 @@ let rec run_nested () =
   Nested.x ();
   Nested.w ()
 
-(* FIXME: name resolution is wonky here and Nested.x is resolved to x.
- *)
 let run_nested_ambiguous () =
   let x () = 1 in
   Nested.x ()

--- a/tests/compiler/expressions.t/run.t
+++ b/tests/compiler/expressions.t/run.t
@@ -414,7 +414,7 @@
   Warning 10: this expression should have type unit.
   File "names.ml", line 4, characters 6-7:
   Warning 26: unused variable x.
-  File "names.ml", line 21, characters 6-7:
+  File "names.ml", line 19, characters 6-7:
   Warning 26: unused variable x.
   Compiling names__nested.erl	OK
   Compiling names.erl	OK
@@ -446,7 +446,7 @@
     X = fun
     () -> 1
   end,
-    X().
+    names__nested:x().
   
   
   $ caramel compile records.ml


### PR DESCRIPTION
This is seemingly solving the issue because when the ocaml name is qualified, the erlang name also will be. I would need to understand the `Texp_ident` contents to see what to check in the typedtree before even translating the name to erlang instead to fix properly, but I was having a hard time debugging ocaml code.

Closes #58