### PR TITLE
Depend on ocamlformat 0.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ setup:
 	opam install --deps-only --with-test ./vendor/ocamlformat-0.16.0/ocamlformat_lib.opam
 	opam install --deps-only --with-test ./vendor/ocaml-lsp-1.4.0/jsonrpc.opam
 	opam install --deps-only --with-test ./vendor/ocaml-lsp-1.4.0/lsp.opam
-	opam install ocamlformat=0.16.0  # this is required, since ocaml-lsp pulls in ocamlformat 0.17
 	opam install --deps-only --with-test ./vendor/ocaml-lsp-1.4.0/ocaml-lsp-server.opam
 	opam install --deps-only ./caramel.opam
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ setup:
 	opam install --deps-only --with-test ./vendor/ocamlformat-0.16.0/ocamlformat_lib.opam
 	opam install --deps-only --with-test ./vendor/ocaml-lsp-1.4.0/jsonrpc.opam
 	opam install --deps-only --with-test ./vendor/ocaml-lsp-1.4.0/lsp.opam
+	opam install ocamlformat=0.16.0  # this is required, since ocaml-lsp pulls in ocamlformat 0.17
 	opam install --deps-only --with-test ./vendor/ocaml-lsp-1.4.0/ocaml-lsp-server.opam
 	opam install --deps-only ./caramel.opam
 

--- a/caramel.opam
+++ b/caramel.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/AbstractMachinesLab/caramel"
 bug-reports: "https://github.com/AbstractMachinesLab/caramel/issues"
 depends: [
   "dune" {>= "2.8" & >= "2.8"}
-  "ocamlformat" {>= "0.16"}
+  "ocamlformat" {= "0.16.0"}
   "ocaml" {>= "4.11.1"}
   "alcotest"
   "bos"

--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,7 @@
  (description "Caramel is a functional language for building type-safe, scalable, and maintainable applications.")
  (depends
   (dune (>= "2.8"))
-  (ocamlformat (>= "0.16"))
+  (ocamlformat (= "0.16.0"))
   (ocaml (>= "4.11.1"))
   alcotest
   bos


### PR DESCRIPTION
I tried building main @ 8b16ae6, but it pulled in ocamlformat 0.17. As long as the vendored ocamlformat_lib is 0.16, ocamlformat has to be 0.16, too. Otherwise, compile errors  break `make build` and `make test` (please see Discord #general for details of the errors).