### PR TITLE
feat(reason): add reason support

### DIFF
--- a/caramel.opam
+++ b/caramel.opam
@@ -13,6 +13,7 @@ depends: [
   "dune" {>= "2.8" & >= "2.8"}
   "ocamlformat" {= "0.16.0"}
   "ocaml" {>= "4.11.1"}
+  "reason"
   "alcotest"
   "bos"
   "erlang"

--- a/caramel/compiler/comp_misc/source_tagger.ml
+++ b/caramel/compiler/comp_misc/source_tagger.ml
@@ -5,7 +5,16 @@ exception Unsupported_file_type_for_target of (Target.t * string * string)
 type tag =
   | Ml of string
   | Mli of string
+  | Re of string
+  | Rei of string
   | Other of (Target.t * string * string)
+
+let pp ppf = function
+  | Ml file -> Format.fprintf ppf "Ml %s" file
+  | Mli file -> Format.fprintf ppf "Mli %s" file
+  | Re file -> Format.fprintf ppf "Re %s" file
+  | Rei file -> Format.fprintf ppf "Rei %s" file
+  | Other _ -> Format.fprintf ppf "Other"
 
 let tag target filename =
   match target with
@@ -13,6 +22,8 @@ let tag target filename =
       match Filename.extension filename with
       | ".ml" -> Ml filename
       | ".mli" -> Mli filename
+      | ".re" -> Re filename
+      | ".rei" -> Rei filename
       | ext -> Other (target, filename, ext))
 
 let assert_all_sources_are_supported sources =
@@ -33,8 +44,9 @@ let prepare ~sources ~target =
 
   let ml_sources =
     tagged_sources
-    |> List.filter_map (function Ml f | Mli f -> Some f | _ -> None)
-    |> Dependency_sorter.sorted_files
+    |> List.filter_map (function
+         | Ml f | Mli f | Re f | Rei f -> Some f
+         | Other _ -> None)
     |> List.map (tag target)
   in
 

--- a/caramel/compiler/compiler.ml
+++ b/caramel/compiler/compiler.ml
@@ -52,6 +52,9 @@ let compile_one source ~target ~opts =
     | Mli file, _ -> (Optcompile.interface, file)
     | Ml file, Erlang -> (Ocaml_to_erlang.compile ~opts, file)
     | Ml file, Core_erlang -> (Ocaml_to_core_erlang.compile ~opts, file)
+    | Rei file, _ -> (Reason_to_erlang.interface ~opts, file) (* TODO *)
+    | Re file, Erlang -> (Reason_to_erlang.compile ~opts, file)
+    | Re file, Core_erlang -> (Ocaml_to_core_erlang.compile ~opts, file)
     | Other (t, file, ext), _ ->
         raise (Unsupported_file_type_for_target (t, file, ext))
   in

--- a/caramel/compiler/dune
+++ b/caramel/compiler/dune
@@ -6,6 +6,7 @@
  (libraries
   caramel.compiler.ocaml_to_erlang
   caramel.compiler.ocaml_to_core_erlang
+  caramel.compiler.reason_to_erlang
   caramel.compiler.misc
   compiler-libs.common
   compiler-libs.optcomp

--- a/caramel/compiler/reason_to_erlang/dune
+++ b/caramel/compiler/reason_to_erlang/dune
@@ -1,0 +1,10 @@
+(library
+ (name reason_to_erlang)
+ (public_name caramel.compiler.reason_to_erlang)
+ (instrumentation
+  (backend bisect_ppx))
+ (libraries
+  caramel.compiler.ocaml_to_erlang
+  compiler-libs.common
+  erlang
+  reason))

--- a/caramel/compiler/reason_to_erlang/reason_to_erlang.ml
+++ b/caramel/compiler/reason_to_erlang/reason_to_erlang.ml
@@ -1,0 +1,68 @@
+open Compile_common
+
+let tool_name = "caramel:re-to-erl"
+
+let setup_lexbuf ~parser source_file =
+  let ic = open_in source_file in
+  try
+    seek_in ic 0;
+    let lexbuf = Lexing.from_channel ic in
+    Location.init lexbuf source_file;
+    parser lexbuf
+  with e ->
+    Format.fprintf Format.std_formatter "Reason parser error: %s"
+      (Printexc.to_string e);
+    close_in_noerr ic;
+    exit 1
+
+let read_signature info =
+  let module_name = info.module_name in
+  let cmi_file = module_name ^ ".cmi" in
+  try
+    let intf_file = Load_path.find_uncap cmi_file in
+    let sign = Env.read_signature module_name intf_file in
+    Some sign
+  with Not_found -> None
+
+let parse_implementation source_file =
+  let implementation lexbuf =
+    lexbuf |> Reason_toolchain.RE.implementation
+    |> Reason_toolchain.To_current.copy_structure
+  in
+  setup_lexbuf ~parser:implementation source_file
+
+let parse_interface source_file =
+  let interface lexbuf =
+    lexbuf |> Reason_toolchain.RE.interface
+    |> Reason_toolchain.To_current.copy_signature
+  in
+  setup_lexbuf ~parser:interface source_file
+
+let interface ~source_file ~output_prefix ~opts:_ =
+  Compile_common.with_info ~native:false ~tool_name ~source_file ~output_prefix
+    ~dump_ext:"cmo"
+  @@ fun info ->
+  Profile.record_call source_file @@ fun () ->
+  let parsetree = parse_interface source_file in
+  if Clflags.(should_stop_after Compiler_pass.Parsing) then ()
+  else
+    let tsg = typecheck_intf info parsetree in
+    if not !Clflags.print_types then emit_signature info parsetree tsg
+
+let compile ~source_file ~output_prefix ~opts:_ =
+  Compile_common.with_info ~native:false ~tool_name ~source_file ~output_prefix
+    ~dump_ext:"cmo"
+  @@ fun info ->
+  let parsetree = parse_implementation source_file in
+  let typed, _coercion =
+    parsetree
+    |> Profile.(record typing)
+         (Typemod.type_implementation info.source_file info.output_prefix
+            info.module_name info.env)
+  in
+  let module_name = info.module_name in
+  let signature = read_signature info in
+  let erl_ast =
+    Ocaml_to_erlang.Ast_transl.from_typedtree ~module_name ~signature typed
+  in
+  Erlang.Printer.to_sources erl_ast

--- a/caramel/verify/dune
+++ b/caramel/verify/dune
@@ -6,6 +6,7 @@
  (libraries
   cmdliner
   erlang
+  reason
   caramel.compiler.ocaml_to_erlang
   caramel.compiler.misc
   compiler-libs.common

--- a/caramel/verify/typing.ml
+++ b/caramel/verify/typing.ml
@@ -21,6 +21,8 @@ let check_one source =
     match source with
     | Mli file -> (Ocaml.interface, file)
     | Ml file -> (Ocaml.implementation, file)
+    | Re file -> (Ocaml.implementation, file) (* TODO *)
+    | Rei file -> (Ocaml.implementation, file)
     | Other (t, file, ext) ->
         raise (Unsupported_file_type_for_target (t, file, ext))
   in

--- a/dune-project
+++ b/dune-project
@@ -20,6 +20,7 @@
   (dune (>= "2.8"))
   (ocamlformat (= "0.16.0"))
   (ocaml (>= "4.11.1"))
+  reason
   alcotest
   bos
   erlang

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -30,21 +30,21 @@
    %{dep:../caramel/bin/main.exe}
    compile
    --no-stdlib
-   io.mli
-   beam.ml
-   core.ml
    binary.ml
    calendar.ml
-   caramel_runtime.ml
    erlang.ml
    ets.ml
-   io.ml
    lists.ml
-   result.ml
    maps.ml
    math.ml
+   caramel_runtime.ml
+   core.ml
+   timer.ml
    process.ml
-   timer.ml)))
+   io.mli
+   beam.ml
+   io.ml
+   result.ml)))
 
 (install
  (section lib)

--- a/tests/compiler/functions.t/basic.re
+++ b/tests/compiler/functions.t/basic.re
@@ -1,0 +1,5 @@
+let pair = (x, y) => (x, y);
+
+let combine = ((a, b), (c, d)) => ((a, c), (b, d));
+
+let ignore = () => ();

--- a/tests/compiler/functions.t/run.t
+++ b/tests/compiler/functions.t/run.t
@@ -1,5 +1,6 @@
-  $ ls *.ml *.mli
+  $ ls *.ml *.mli *.re *.rei
   basic.ml
+  basic.re
   guard_unsupported.ml
   guards.ml
   hello_joe.ml
@@ -13,6 +14,8 @@
   sequencing.ml
   uncurry.ml
   uncurry.mli
+  uncurry.re
+  uncurry.rei
 
   $ caramel compile basic.ml
   Compiling basic.erl	OK
@@ -34,7 +37,8 @@
   ignore() -> ok.
   
   
-
+  $ caramel compile basic.re
+  Compiling basic.erl	OK
   $ caramel compile hello_joe.ml
   Compiling hello_joe.erl	OK
   $ cat hello_joe.erl
@@ -182,7 +186,7 @@
   
   
 
-  $ caramel compile qualified_calls.ml qualified_calls_helper.ml
+  $ caramel compile qualified_calls_helper.ml qualified_calls.ml 
   Compiling qualified_calls_helper__nested.erl	OK
   Compiling qualified_calls_helper.erl	OK
   Compiling qualified_calls__nested.erl	OK
@@ -268,7 +272,7 @@
   
   
 
-  $ caramel compile uncurry.ml uncurry.mli
+  $ caramel compile uncurry.mli uncurry.ml 
   Compiling uncurry.erl	OK
   $ cat uncurry.erl
   % Source code generated with Caramel.
@@ -298,6 +302,9 @@
   add_really_slow(X, ok, Y, ok) -> erlang:'+'(X, Y).
   
   
+
+  $ caramel compile uncurry.rei uncurry.re
+  Compiling uncurry.erl	OK
 
   $ caramel compile redefine.ml
   We have found 2 definitions of the function: f in module redefine.

--- a/tests/compiler/functions.t/uncurry.re
+++ b/tests/compiler/functions.t/uncurry.re
@@ -1,0 +1,27 @@
+type ignore = unit => unit;
+
+/* FIXME: this should compile to
+ *
+ *  ignore(_X) -> fun() -> ok end.
+ */
+
+let ignore = (_x, ()) => ();
+
+type defer('a) = unit => 'a;
+
+let add = (x, y) => x + x;
+
+/* FIXME: should compile to:
+ *
+ *  add_slow(X, Y) -> fun() -> ... end.
+ */
+let add_slow = (x, y, ()) => x + y;
+
+/* NOTE: very debatable. Need to discuss more.
+ *
+ * FIXME: this should compile to
+ *
+ *  add_really_slow(X) -> fun(Y) -> fun() -> erlang:'+'(X, Y) end end.
+ *
+ */
+let add_really_slow = (x, (), y, ()) => x + y;

--- a/tests/compiler/functions.t/uncurry.rei
+++ b/tests/compiler/functions.t/uncurry.rei
@@ -1,0 +1,17 @@
+/* FIXME: this should compile to: fun() -> ok
+ * since ok is the "unit" or Erlang for return calls
+ */
+type ignore = unit => unit;
+
+/* FIXME: this should compile to: fun() -> A
+ * since "unit" should go away if its the only argument
+ */
+type defer('a) = unit => 'a;
+
+let ignore: 'a => ignore;
+
+let add: (int, int) => int;
+
+let add_slow: (int, int) => defer(int);
+
+let add_really_slow: int => defer(int => defer(int));

--- a/tests/compiler/modules.t/run.t
+++ b/tests/compiler/modules.t/run.t
@@ -10,18 +10,18 @@
   sig.mli
   sig_dep.ml
   simple_nested.ml
-  $ caramel compile *.ml *.mli
-  Compiling simple_nested__a.erl	OK
-  Compiling simple_nested__b.erl	OK
-  Compiling simple_nested.erl	OK
-  Compiling sig.erl	OK
+  $ caramel compile *.mli *.ml 
+  Compiling functors.erl	OK
+  Compiling include__a.erl	OK
+  Compiling include.erl	OK
+  Compiling let_open__a.erl	OK
   Compiling nested__a__c.erl	OK
   Compiling nested__a.erl	OK
   Compiling nested__b.erl	OK
-  Compiling let_open__a.erl	OK
-  Compiling include__a.erl	OK
-  Compiling include.erl	OK
-  Compiling functors.erl	OK
+  Compiling sig.erl	OK
+  Compiling simple_nested__a.erl	OK
+  Compiling simple_nested__b.erl	OK
+  Compiling simple_nested.erl	OK
   $ echo $?
   0
   $ cat *.erl

--- a/tests/compiler/stdlib.t/run.t
+++ b/tests/compiler/stdlib.t/run.t
@@ -3,9 +3,9 @@
   using_io.ml
   using_math.ml
   $ caramel compile *.ml
-  Compiling using_math.erl	OK
-  Compiling using_io.erl	OK
   Compiling using_core.erl	OK
+  Compiling using_io.erl	OK
+  Compiling using_math.erl	OK
   $ echo $?
   0
   $ cat *.erl

--- a/tests/compiler/types.t/run.t
+++ b/tests/compiler/types.t/run.t
@@ -11,18 +11,18 @@
   type_alias.ml
   type_args.ml
   variants.ml
-  $ caramel compile *.ml *.mli
-  Compiling variants.erl	OK
-  Compiling type_args.erl	OK
+  $ caramel compile *.mli type_alias.ml type_args.ml record.ml fn.ml polymorphic_variants.ml variants.ml qualified_names.ml opaque_and_hidden.ml inductive.ml extensible_variant.ml abstract.ml
   Compiling type_alias.erl	OK
+  Compiling type_args.erl	OK
   Compiling record.erl	OK
+  Compiling fn.erl	OK
   Compiling polymorphic_variants.erl	OK
+  Compiling variants.erl	OK
+  Compiling qualified_names.erl	OK
   Compiling opaque_and_hidden.erl	OK
   Compiling inductive.erl	OK
-  Compiling fn.erl	OK
   Compiling extensible_variant.erl	OK
   Compiling abstract.erl	OK
-  Compiling qualified_names.erl	OK
   $ echo $?
   0
   $ cat *.erl


### PR DESCRIPTION
Closes #18 

I accidentally screwed up my previous branch and it resulted in GitHub automatically closing the PR I was working with (https://github.com/AbstractMachinesLab/caramel/pull/46)

I figured the easiest way in my case to recover from this mess was to make a new branch with all my changes. We wanted to squash anyway...


- As we agreed, I removed the testing bash script so it will work with all OSes, until we make a robust convenience script in OCaml for testing Reason syntax
- This PR does not support the `verify` step
- This PR does not support the `reason -> Core Erlang` target, only `reason -> Erlang`.