### PR TITLE
fix(compiler): allow to run directly from bin directory

### DIFF
--- a/caramel/compiler/compiler.ml
+++ b/caramel/compiler/compiler.ml
@@ -9,8 +9,8 @@ let tool_name = "caramel"
 let default_stdlib_path =
   let ( / ) = Filename.concat in
   let dirname = Filename.dirname in
-  let root = dirname (dirname Sys.executable_name) in
-  root / "lib" / "caramel" / "stdlib"
+  let bin_dir = dirname Sys.executable_name in
+  bin_dir / ".." / "lib" / "caramel" / "stdlib"
 
 module Backend = struct
   (* See backend_intf.mli. *)


### PR DESCRIPTION
Before:
```
~/.opam/default/bin$ cat main.ml
let main _ = Io.format "~s~n" ["Hello World"]
~/.opam/default/bin$ ./caramel compile main.ml 
Unbound module Beam
```

After:
```
~/.opam/default/bin$ ./caramel compile main.ml 
Compiling main.erl      OK
```