### PR TITLE
chore(ci): only run ci on main branch and pull requests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   create_draft_release:


### PR DESCRIPTION
When contributing to Caramel from a forked repository, for example working on an opened PR, I noticed that there are double CI builds happening: one in the `AbstractMachinesLab / caramel` repo, and one in my fork. This is confusing and it seems a bit wasteful.

This PR changes the CI configuration so that it runs on each commit only on the `main` branch or from opened pull requests, so there should not be duplicated CI workflows triggered from a forked repository in the most common contribution flow.