### PR TITLE
Pipe operator support

### DIFF
--- a/caramel/compiler/ocaml_to_erlang/names.ml
+++ b/caramel/compiler/ocaml_to_erlang/names.ml
@@ -158,6 +158,10 @@ let ocaml_to_erlang_primitive_op t =
       Name.qualified
         ~m:(Name.atom (Atom.mk "caramel_runtime"))
         ~f:(Name.atom (Atom.mk "binary_concat"))
+  | "|>" ->
+      Name.qualified
+        ~m:(Name.atom (Atom.mk "caramel_runtime"))
+        ~f:(Name.atom (Atom.mk "pipe"))
   | "!=" | "<>" -> to_erl_op "=/="
   | "not" -> to_erl_op "not"
   | "&&" -> to_erl_op "and"

--- a/stdlib/caramel_runtime.erl
+++ b/stdlib/caramel_runtime.erl
@@ -2,6 +2,7 @@
 
 -export([
          binary_concat/2,
+         pipe/2,
          recv/0,
          recv/1
         ]).
@@ -16,3 +17,5 @@ recv(Timeout) ->
 
 binary_concat(A, B) when is_binary(A) and is_binary(B) ->
   << (A)/binary, (B)/binary >>.
+
+pipe(A, B) -> B A.

--- a/stdlib/caramel_runtime.erl
+++ b/stdlib/caramel_runtime.erl
@@ -18,4 +18,4 @@ recv(Timeout) ->
 binary_concat(A, B) when is_binary(A) and is_binary(B) ->
   << (A)/binary, (B)/binary >>.
 
-pipe(A, B) -> B A.
+pipe(A, B) -> B(A).

--- a/stdlib/caramel_runtime.ml
+++ b/stdlib/caramel_runtime.ml
@@ -3,3 +3,5 @@ external recv_with_timeout : int -> 'a = "recv"
 external recv_and_wait : unit -> 'a = "recv"
 
 external ( ^ ) : string -> string -> string = "binary_concat"
+
+external ( |> ) : 'a -> 'b -> 'c = "pipe"

--- a/stdlib/caramel_runtime.ml
+++ b/stdlib/caramel_runtime.ml
@@ -4,4 +4,4 @@ external recv_and_wait : unit -> 'a = "recv"
 
 external ( ^ ) : string -> string -> string = "binary_concat"
 
-external ( |> ) : 'a -> 'b -> 'c = "pipe"
+external ( |> ) : 'a -> ('a -> 'b) -> 'b = "pipe"

--- a/tests/compiler/functions.t/pipe.ml
+++ b/tests/compiler/functions.t/pipe.ml
@@ -1,0 +1,6 @@
+let print_int number = Io.format "~0tp~n" [ number ]
+
+let subtract x y = y - x
+let main _ =
+  let divide x y = y / x in
+  10 |> subtract 2 |> divide 4 |> print_int

--- a/tests/compiler/functions.t/run.t
+++ b/tests/compiler/functions.t/run.t
@@ -238,7 +238,7 @@
   -spec subtract(integer(), integer()) -> integer().
   subtract(X, Y) -> erlang:'-'(Y, X).
   
-  -spec main(_) -> _.
+  -spec main(_) -> ok.
   main(_) ->
     Divide = fun
       (X, Y) -> erlang:'div'(Y, X)

--- a/tests/compiler/functions.t/run.t
+++ b/tests/compiler/functions.t/run.t
@@ -10,6 +10,7 @@
   multiple_clauses.ml
   partial_functions.ml
   pattern_aliases.ml
+  pipe.ml
   qualified_calls.ml
   qualified_calls_helper.ml
   redefine.ml
@@ -221,6 +222,31 @@
     end.
   
   
+  $ caramel compile pipe.ml
+  Compiling pipe.erl	OK
+  $ cat pipe.erl
+  % Source code generated with Caramel.
+  -module(pipe).
+  
+  -export([main/1]).
+  -export([print_int/1]).
+  -export([subtract/2]).
+  
+  -spec print_int(_) -> ok.
+  print_int(Number) -> io:format(<<"~0tp~n">>, [Number | []]).
+  
+  -spec subtract(integer(), integer()) -> integer().
+  subtract(X, Y) -> erlang:'-'(Y, X).
+  
+  -spec main(_) -> _.
+  main(_) ->
+    Divide = fun
+      (X, Y) -> erlang:'div'(Y, X)
+    end,
+    caramel_runtime:pipe(caramel_runtime:pipe(caramel_runtime:pipe(10, subtract(2)), Divide(4)), fun print_int/1).
+  
+  
+
   $ caramel compile qualified_calls_helper.ml qualified_calls.ml 
   Compiling qualified_calls_helper__nested.erl	OK
   Compiling qualified_calls_helper.erl	OK


### PR DESCRIPTION
Closes #72

This PR adds pipe operator support (`|>`).
It is in Draft because we have to wait for #44 to be resolved first. (As mentionned [here](https://github.com/AbstractMachinesLab/caramel/issues/72#issuecomment-791216993))